### PR TITLE
Remove T prefix from typeParameter naming-convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ module.exports = {
 			{
 				selector: "typeParameter",
 				format: ["PascalCase"],
-				prefix: ["T"],
 			},
 			/* eslint-enable sort-keys */
 		],


### PR DESCRIPTION
As a general (heh) rule, using `T` is good. But prefixing everything with `T` leads to messiness:

```typescript
export type OverrideForRelation<T, R> = Overrides<R extends undefined ? T : R>;
```
will not be helped if R is prefixed with a T:

```typescript
export type OverrideForRelation<T, TR> = Overrides<TR extends undefined ? T : TR>;
```